### PR TITLE
Ensure that the returned KeyID is also zero-padded

### DIFF
--- a/models/asymkey/gpg_key.go
+++ b/models/asymkey/gpg_key.go
@@ -64,11 +64,16 @@ func (key *GPGKey) AfterLoad(session *xorm.Session) {
 
 // PaddedKeyID show KeyID padded to 16 characters
 func (key *GPGKey) PaddedKeyID() string {
-	if len(key.KeyID) > 15 {
-		return key.KeyID
+	return PaddedKeyID(key.KeyID)
+}
+
+// PaddedKeyID show KeyID padded to 16 characters
+func PaddedKeyID(keyID string) string {
+	if len(keyID) > 15 {
+		return keyID
 	}
 	zeros := "0000000000000000"
-	return zeros[0:16-len(key.KeyID)] + key.KeyID
+	return zeros[0:16-len(keyID)] + keyID
 }
 
 // ListGPGKeys returns a list of public keys belongs to given user.

--- a/routers/web/user/setting/keys.go
+++ b/routers/web/user/setting/keys.go
@@ -99,14 +99,18 @@ func KeysPost(ctx *context.Context) {
 				loadKeysData(ctx)
 				ctx.Data["Err_Content"] = true
 				ctx.Data["Err_Signature"] = true
-				ctx.Data["KeyID"] = err.(asymkey_model.ErrGPGInvalidTokenSignature).ID
+				keyID := err.(asymkey_model.ErrGPGInvalidTokenSignature).ID
+				ctx.Data["KeyID"] = keyID
+				ctx.Data["PaddedKeyID"] = asymkey_model.PaddedKeyID(keyID)
 				ctx.RenderWithErr(ctx.Tr("settings.gpg_invalid_token_signature"), tplSettingsKeys, &form)
 			case asymkey_model.IsErrGPGNoEmailFound(err):
 				loadKeysData(ctx)
 
 				ctx.Data["Err_Content"] = true
 				ctx.Data["Err_Signature"] = true
-				ctx.Data["KeyID"] = err.(asymkey_model.ErrGPGNoEmailFound).ID
+				keyID := err.(asymkey_model.ErrGPGNoEmailFound).ID
+				ctx.Data["KeyID"] = keyID
+				ctx.Data["PaddedKeyID"] = asymkey_model.PaddedKeyID(keyID)
 				ctx.RenderWithErr(ctx.Tr("settings.gpg_no_key_email_found"), tplSettingsKeys, &form)
 			default:
 				ctx.ServerError("AddPublicKey", err)
@@ -138,7 +142,9 @@ func KeysPost(ctx *context.Context) {
 				loadKeysData(ctx)
 				ctx.Data["VerifyingID"] = form.KeyID
 				ctx.Data["Err_Signature"] = true
-				ctx.Data["KeyID"] = err.(asymkey_model.ErrGPGInvalidTokenSignature).ID
+				keyID := err.(asymkey_model.ErrGPGInvalidTokenSignature).ID
+				ctx.Data["KeyID"] = keyID
+				ctx.Data["PaddedKeyID"] = asymkey_model.PaddedKeyID(keyID)
 				ctx.RenderWithErr(ctx.Tr("settings.gpg_invalid_token_signature"), tplSettingsKeys, &form)
 			default:
 				ctx.ServerError("VerifyGPG", err)

--- a/templates/user/settings/keys_gpg.tmpl
+++ b/templates/user/settings/keys_gpg.tmpl
@@ -22,7 +22,7 @@
 					<input readonly="" value="{{.TokenToSign}}">
 					<div class="help">
 						<p>{{.locale.Tr "settings.gpg_token_help"}}</p>
-						<p><code>{{$.locale.Tr "settings.gpg_token_code" .TokenToSign .KeyID}}</code></p>
+						<p><code>{{$.locale.Tr "settings.gpg_token_code" .TokenToSign .PaddedKeyID}}</code></p>
 					</div>
 				</div>
 				<div class="field">


### PR DESCRIPTION
The erroring KeyID may need to be leftpadded with `0`.